### PR TITLE
Updates services and config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.4 | ^7.0",
         "rebelcode/modular": "^0.1-alpha1",
         "rebelcode/rc-booking": "^0.1-alpha1",
-        "rebelcode/booking-transitioner": "^0.2-alpha1",
+        "rebelcode/booking-transitioner": "^0.2-alpha2",
         "rebelcode/event-state-machine": "^0.2-alpha1",
         "rebelcode/session-generator": "^0.1-alpha1",
         "dhii/psr-14": "^0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f47be7103828845a48d626381dea24de",
+    "content-hash": "d008a46de6665aa6a9dcdea751fa4dbc",
     "packages": [
         {
             "name": "dhii/args-list-validation",
@@ -209,16 +209,16 @@
         },
         {
             "name": "dhii/container-helper-base",
-            "version": "v0.1-alpha7",
+            "version": "v0.1-alpha8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/container-helper-base.git",
-                "reference": "622671534124d95c1478a744e4d903b4d071f674"
+                "reference": "1b8206842e06b71abcff769aaddfc51bf8f317cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/container-helper-base/zipball/622671534124d95c1478a744e4d903b4d071f674",
-                "reference": "622671534124d95c1478a744e4d903b4d071f674",
+                "url": "https://api.github.com/repos/Dhii/container-helper-base/zipball/1b8206842e06b71abcff769aaddfc51bf8f317cd",
+                "reference": "1b8206842e06b71abcff769aaddfc51bf8f317cd",
                 "shasum": ""
             },
             "require": {
@@ -254,7 +254,7 @@
                 }
             ],
             "description": "Helper functionality for working with container.",
-            "time": "2018-04-10T15:03:55+00:00"
+            "time": "2018-07-30T09:59:15+00:00"
         },
         {
             "name": "dhii/data-container-abstract",
@@ -1594,16 +1594,16 @@
         },
         {
             "name": "dhii/map",
-            "version": "v0.1-alpha6",
+            "version": "v0.1-alpha7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/map.git",
-                "reference": "7b11540e02ff1d6cd2efc5f4da8730c6a40076fa"
+                "reference": "9ec82af42b7cb33d3b0b70d753e8a2bc7451cedf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/map/zipball/7b11540e02ff1d6cd2efc5f4da8730c6a40076fa",
-                "reference": "7b11540e02ff1d6cd2efc5f4da8730c6a40076fa",
+                "url": "https://api.github.com/repos/Dhii/map/zipball/9ec82af42b7cb33d3b0b70d753e8a2bc7451cedf",
+                "reference": "9ec82af42b7cb33d3b0b70d753e8a2bc7451cedf",
                 "shasum": ""
             },
             "require": {
@@ -1653,7 +1653,7 @@
                 "iterable",
                 "map"
             ],
-            "time": "2018-04-30T10:18:06+00:00"
+            "time": "2018-07-30T10:48:11+00:00"
         },
         {
             "name": "dhii/module-interface",
@@ -2286,16 +2286,16 @@
         },
         {
             "name": "rebelcode/booking-transitioner",
-            "version": "dev-develop",
+            "version": "v0.2-alpha2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RebelCode/booking-transitioner.git",
-                "reference": "d82b887425168f69046cf951194daeb9271d524c"
+                "reference": "5432f0d2b01cf6e431162fc0d1cbabd2a3f552f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RebelCode/booking-transitioner/zipball/d82b887425168f69046cf951194daeb9271d524c",
-                "reference": "d82b887425168f69046cf951194daeb9271d524c",
+                "url": "https://api.github.com/repos/RebelCode/booking-transitioner/zipball/5432f0d2b01cf6e431162fc0d1cbabd2a3f552f7",
+                "reference": "5432f0d2b01cf6e431162fc0d1cbabd2a3f552f7",
                 "shasum": ""
             },
             "require": {
@@ -2338,20 +2338,20 @@
                 }
             ],
             "description": "Booking transitioner implementations.",
-            "time": "2018-07-27T09:23:22+00:00"
+            "time": "2018-07-31T11:36:30+00:00"
         },
         {
             "name": "rebelcode/event-state-machine",
-            "version": "dev-develop",
+            "version": "v0.2-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RebelCode/event-state-machine.git",
-                "reference": "94f64e23ab94c0fa88390c8e3991b06536044479"
+                "reference": "5639f11dcc06de464bc7978002a5399be1f113e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RebelCode/event-state-machine/zipball/94f64e23ab94c0fa88390c8e3991b06536044479",
-                "reference": "94f64e23ab94c0fa88390c8e3991b06536044479",
+                "url": "https://api.github.com/repos/RebelCode/event-state-machine/zipball/5639f11dcc06de464bc7978002a5399be1f113e9",
+                "reference": "5639f11dcc06de464bc7978002a5399be1f113e9",
                 "shasum": ""
             },
             "require": {
@@ -2397,7 +2397,7 @@
                 }
             ],
             "description": "An event-based state machine implementation.",
-            "time": "2018-07-26T14:24:24+00:00"
+            "time": "2018-07-27T09:38:13+00:00"
         },
         {
             "name": "rebelcode/modular",

--- a/src/BookingLogicModule.php
+++ b/src/BookingLogicModule.php
@@ -93,7 +93,7 @@ class BookingLogicModule extends AbstractBaseModule
                     return new EventStateMachineFactory(
                         $c->get('event_manager'),
                         $c->get('booking_transition_event_factory'),
-                        $c->get('booking_logic/state_machine/transition_event_format')
+                        $c->get('booking_logic/transition_event_format')
                     );
                 },
                 /**

--- a/src/BookingLogicModule.php
+++ b/src/BookingLogicModule.php
@@ -102,19 +102,7 @@ class BookingLogicModule extends AbstractBaseModule
                  * @since [*next-version*]
                  */
                 'booking_transition_event_factory'           => function (ContainerInterface $c) {
-                    return new GenericCallbackFactory(function ($config) {
-                        $name       = $this->_containerGet($config, 'name');
-                        $transition = $this->_containerGet($config, 'transition');
-
-                        $target = $this->_containerHas($config, 'target')
-                            ? $this->_containerGet($config, 'target')
-                            : null;
-                        $params = $this->_containerHas($config, 'params')
-                            ? $this->_containerGet($config, 'params')
-                            : null;
-
-                        return new TransitionEvent($name, $transition, $target, $params);
-                    });
+                    return new TransitionEventFactory();
                 },
             ]
         );

--- a/src/BookingLogicModule.php
+++ b/src/BookingLogicModule.php
@@ -79,7 +79,7 @@ class BookingLogicModule extends AbstractBaseModule
                  */
                 'booking_transitioner'                       => function (ContainerInterface $c) {
                     return new BookingTransitioner(
-                        $c->get('booking_logic/state_machine/status_transitions'),
+                        $c->get('booking_logic/status_transitions'),
                         $c->get('booking_transitioner_state_machine_factory'),
                         $c->get('booking_factory')
                     );

--- a/src/TransitionEventFactory.php
+++ b/src/TransitionEventFactory.php
@@ -130,7 +130,7 @@ class TransitionEventFactory implements EventFactoryInterface
         $transition = $this->_containerGet($config, static::K_CFG_TRANSITION);
 
         $params = $this->_containerHas($config, static::K_CFG_PARAMS)
-            ? $this->_containerGet($config, 'static::K_CFG_PARAMS')
+            ? $this->_containerGet($config, static::K_CFG_PARAMS)
             : null;
         $target = $this->_containerHas($config, static::K_CFG_TARGET)
             ? $this->_containerGet($config, static::K_CFG_TARGET)

--- a/src/TransitionEventFactory.php
+++ b/src/TransitionEventFactory.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace RebelCode\Bookings\Module;
+
+use Dhii\Data\Container\ContainerGetCapableTrait;
+use Dhii\Data\Container\ContainerHasCapableTrait;
+use Dhii\Data\Container\CreateContainerExceptionCapableTrait;
+use Dhii\Data\Container\CreateNotFoundExceptionCapableTrait;
+use Dhii\Data\Container\NormalizeKeyCapableTrait;
+use Dhii\Event\EventFactoryInterface;
+use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
+use Dhii\Exception\CreateOutOfRangeExceptionCapableTrait;
+use Dhii\I18n\StringTranslatingTrait;
+use Dhii\Util\Normalization\NormalizeStringCapableTrait;
+use RebelCode\State\TransitionEvent;
+
+/**
+ * A factory for creating transition event instances.
+ *
+ * @since [*next-version*]
+ */
+class TransitionEventFactory implements EventFactoryInterface
+{
+    /*
+     * Provides functionality for reading from any type of container.
+     *
+     * @since [*next-version*]
+     */
+    use ContainerGetCapableTrait;
+
+    /*
+     * Provides functionality for key-checking any type of container.
+     *
+     * @since [*next-version*]
+     */
+    use ContainerHasCapableTrait;
+
+    /*
+     * Provides key normalization functionality.
+     *
+     * @since [*next-version*]
+     */
+    use NormalizeKeyCapableTrait;
+
+    /*
+     * Provides string normalization functionality.
+     *
+     * @since [*next-version*]
+     */
+    use NormalizeStringCapableTrait;
+
+    /*
+     * Provides functionality for creating invalid-argument exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateInvalidArgumentExceptionCapableTrait;
+
+    /*
+     * Provides functionality for creating out-of-range exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateOutOfRangeExceptionCapableTrait;
+
+    /*
+     * Provides functionality for creating container exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateContainerExceptionCapableTrait;
+
+    /*
+     * Provides functionality for creating container not-found exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateNotFoundExceptionCapableTrait;
+
+    /*
+     * Provides string translating functionality.
+     *
+     * @since [*next-version*]
+     */
+    use StringTranslatingTrait;
+
+    /**
+     * The key for the event name in the config.
+     *
+     * @since [*next-version*]
+     */
+    const K_CFG_NAME = 'name';
+
+    /**
+     * The key for the event params in the config.
+     *
+     * @since [*next-version*]
+     */
+    const K_CFG_PARAMS = 'params';
+
+    /**
+     * The key for the event target in the config.
+     *
+     * @since [*next-version*]
+     */
+    const K_CFG_TARGET = 'target';
+
+    /**
+     * The key for the event propagation flag in the config.
+     *
+     * @since [*next-version*]
+     */
+    const K_CFG_PROPAGATION = 'propagation';
+
+    /**
+     * The key for the event transition in the config.
+     *
+     * @since [*next-version*]
+     */
+    const K_CFG_TRANSITION = 'transition';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function make($config = null)
+    {
+        $name       = $this->_containerGet($config, static::K_CFG_NAME);
+        $transition = $this->_containerGet($config, static::K_CFG_TRANSITION);
+
+        $params = $this->_containerHas($config, static::K_CFG_PARAMS)
+            ? $this->_containerGet($config, 'static::K_CFG_PARAMS')
+            : null;
+        $target = $this->_containerHas($config, static::K_CFG_TARGET)
+            ? $this->_containerGet($config, static::K_CFG_TARGET)
+            : null;
+
+        return new TransitionEvent($name, $transition, $target, $params);
+    }
+}


### PR DESCRIPTION
The following changes need to be made before merging:

- [ ] Update version constraint for dependency `rebelcode/booking-transitioner` (currently set as `^0.2-alpha1`, which has a bug) when a new release is available for that package.
